### PR TITLE
Update be.py to work with newest better-exception

### DIFF
--- a/naipyext/be.py
+++ b/naipyext/be.py
@@ -73,7 +73,7 @@ def load_ipython_extension(ip: InteractiveShell) -> None:
             [filename, tb_offset, exception_only, issubclass(etype, SyntaxError)]
         )
         if use_better:
-            return print(better_exceptions.format_exception(etype, value, tb))
+            return print(*better_exceptions.format_exception(etype, value, tb), sep="")
 
         return old_show_tb(
             None if notuple else exc_tuple,


### PR DESCRIPTION
`better_exceptions.format_exception(etype, value, tb)` produces a list of lines of traceback